### PR TITLE
Fix for issue #29

### DIFF
--- a/src/main/java/modwarriors/notenoughkeys/keys/KeyEvents.java
+++ b/src/main/java/modwarriors/notenoughkeys/keys/KeyEvents.java
@@ -65,7 +65,9 @@ public class KeyEvents {
 				);
 				if (isInternal != isSpecial) {
 					this.setKeyPressed(keyBinding, isSpecial);
-
+				}
+				if (isSpecial)
+				{
 					if (Minecraft.getMinecraft().currentScreen == null) {
 						// Post the event!
 						MinecraftForge.EVENT_BUS.post(


### PR DESCRIPTION
Keyevent should be triggered when the keybinding is pressed, not when it differs from the current state of the Keybinding.getIsKeyPressed.

This closes #29 